### PR TITLE
fix(nav): add missing groups link and correct auth links for logged-out users

### DIFF
--- a/app/components/NavBar.tsx
+++ b/app/components/NavBar.tsx
@@ -153,8 +153,8 @@ export default function NavBar({
                             >
                                 Home
                             </button>
-                            <NavLink href="/">Login</NavLink>
-                            <NavLink href="/">Create Account</NavLink>
+                            <NavLink href="/login">Login</NavLink>
+                            <NavLink href="/signup">Create Account</NavLink>
                         </div>
                     )}
                 </div>

--- a/app/components/NavBar.tsx
+++ b/app/components/NavBar.tsx
@@ -125,6 +125,7 @@ export default function NavBar({
                                     Messages
                                 </NavLink>
                                 <NavLink href="/chatboxes">Chatbox</NavLink>
+                                <NavLink href="/groups">Groups</NavLink>
                                 <NavLink href="/search">Search</NavLink>
                                 <NavLink
                                     href="/notifications"


### PR DESCRIPTION
## Summary

This pull request resolves two navigation issues in the main navigation bar (`app/components/NavBar.tsx`):


<img width="1535" height="771" alt="image" src="https://github.com/user-attachments/assets/cc82d88a-7270-4bf5-9eb0-0d29a71d876d" />
<img width="1535" height="698" alt="image" src="https://github.com/user-attachments/assets/92812d1f-3531-4459-9f39-019cffdf2caa" />


1. **Add missing Groups link**: The application contains a complete Groups feature (`/groups`), but logged-in users had no navigation link to discover or access it from the top navigation bar. A link to `/groups` is now available alongside the primary navigation items.
2. **Fix logged-out authentication links**: When visitors who are not logged in view public pages (such as `/about`, `/terms`, `/privacy`, or public profile pages `/:username`), the top navigation bar rendered "Login" and "Create Account" links pointing to the root home page (`/`). They have now been updated to point directly to `/login` and `/signup`.

## Changes Made

* `app/components/NavBar.tsx`:
  * Added `<NavLink href="/groups">Groups</NavLink>` to the logged-in navigation list.
  * Updated `<NavLink href="/login">Login</NavLink>` and `<NavLink href="/signup">Create Account</NavLink>` in the logged-out navigation bar.

## Testing Done

* Verified TypeScript type checking passed without errors (`npx tsc --noEmit`).
* Verified navigation links render properly and point to their designated routes.
* Verified working tree is clean across all commits.
