### PR TITLE
feat: add Tetris game with all-users leaderboard

### DIFF
--- a/PR-CHECKS.md
+++ b/PR-CHECKS.md
@@ -1,0 +1,42 @@
+# PR Checks — Tetris & Games Leaderboard
+
+Verification results for the `games/tetris` branch on commit `8cb862f`.
+
+## Test
+
+```bash
+npm test
+```
+
+**Result:** Passed — 16 test files, 102 tests, all green.
+
+- `lib/tetris.test.ts` — engine: movement, rotation/wall kicks, line clears, scoring, gravity, hard drop, game-over.
+- `lib/games.test.ts` — score/play-time validation and leaderboard cursor parsing.
+
+## Build
+
+```bash
+npm run build
+```
+
+**Result:** Passed — compiled successfully, TypeScript clean, 30 pages generated. `/games` route included.
+
+## Lint
+
+```bash
+npm run lint
+```
+
+**Result:** 2 errors + 11 warnings — **all pre-existing, none in games code.**
+
+| Severity | File | Issue |
+|----------|------|-------|
+| error | `app/components/AuthForm.tsx` | setState in effect |
+| error | `app/components/PwaInstallButton.tsx` | setState in effect |
+| warning | `app/components/NavBar.tsx` | unused `isAdmin` (exists on `main`) |
+
+The remaining warnings are unused variables and `<img>` suggestions in `BulletinPostCard`, `PostCard`, `LayoutsGallery`, `MessageRecipientSearch`, `groups/page`, `layouts/[id]/page`, `messages/[id]/page`, and `lib/group.ts`.
+
+Games-specific files (`lib/tetris.*`, `lib/games.*`, `TetrisGame`, `GamesLeaderboard`, `games/page`, `actions`, `types`, `usernames`) lint with **0 errors, 0 warnings**.
+
+> Note: `NavBar.tsx:37` (`isAdmin` unused) and the 2 errors were confirmed to exist on `main` before this branch — not introduced here.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Genggi is a nostalgic social network for custom profiles, friends, messages, com
 - Build a custom profile with layouts, profile details, photos, friends, and testimonials.
 - Share bulletin posts with public, friends-only, or private visibility.
 - Post and watch **Vids** — short vertical videos with likes, comments, sharing, and view counts.
+- Play casual **Games** like Tetris with an all-users high-score leaderboard.
 - Send messages, use chatboxes, join groups, and receive notifications.
 - Search members and report bugs from inside the app.
 
@@ -75,6 +76,31 @@ Genggi is a nostalgic social network for custom profiles, friends, messages, com
 
 To use Google sign-in locally, enable Google as a Firebase Authentication provider and add your local and deployed domains to Firebase's authorized domains. To send email from a custom address, verify the domain in Resend and set `RESEND_FROM`.
 
+### Local quickstart (no external services)
+
+You only need Node.js and a running MongoDB to try the site locally — no Firebase, R2, or Resend required. Games, profiles, messages, chatboxes, groups, and the bulletin all work; photo uploads, Google sign-in, and verification emails need their respective services.
+
+1. Make sure MongoDB is running on `localhost:27017`. If you don't have it installed, use Docker:
+
+    ```bash
+    docker run --name genggi-mongo -d -p 27017:27017 mongo:7
+    ```
+
+2. Install dependencies and seed a demo account plus leaderboard data:
+
+    ```bash
+    npm install
+    node scripts/seed-dev.mjs
+    ```
+
+3. Start the dev server and log in with `demo` / `demo1234`, then visit [http://localhost:3000/games](http://localhost:3000/games).
+
+Notes:
+
+- The seeder is idempotent (re-run it any time) and dev-only — never run it against production. `node scripts/seed-dev.mjs --fresh` wipes `users`, `sessions`, `gameScores`, and `gameScoreSubmissions` before seeding.
+- Point it at another MongoDB with `--uri=`: `node scripts/seed-dev.mjs --uri=mongodb://host:27017/db`.
+- Signing up locally works but won't let you log in until the email is verified (that needs Resend). The seeded `demo` user is pre-verified, which is why the seeder exists.
+
 ## Vids (short-form video)
 
 Vids is the app's short-form vertical video feed at `/vids` (watch), `/vids/upload` (post), and `/vids/{vidId}` (dedicated shareable page). It reuses the existing account system, friendship/follow system, R2 storage, and the `reports` moderation queue.
@@ -108,6 +134,15 @@ Indexes are created idempotently on first use (`ensureVidIndexes`); there is no 
 Abandoned/failed uploads never reached `published` are removed (R2 objects + records) after 24 hours by `cleanupAbandonedVids`. It runs opportunistically from the upload endpoint and via the admin-only `runVidCleanupAction`; in production, point a cron job at that action (e.g. a daily request to a server action). Deleting a Vid removes its R2 objects and all related records, and admin user deletion cleans up the user's Vids too.
 
 No additional environment variables are required — Vids uses the same `R2_BUCKET`, `R2_ENDPOINT`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, and `R2_PUBLIC_URL` as image uploads. The bucket's public URL must serve videos with HTTP range-request support (R2 supports this natively), and the upload route must be reachable with a body limit above 100 MB.
+
+## Games (Tetris)
+
+Games live at `/games` (also linked in the nav). The Tetris client (`app/components/TetrisGame.tsx`) runs a pure, unit-tested engine in `lib/tetris.ts`; the leaderboard shows every player's best score plus your own rank.
+
+- Scores are submitted through `submitGameScoreAction`, which requires login, re-validates the score (integer, within bounds) and play time (≥ 5 seconds), then records only the player's **best** score via `recordGameScore`.
+- `gameScores` — one document per `(gameId, userId)` holding `bestScore`, `gamesPlayed`, and `updatedAt` (earliest to reach a score places higher on ties). Indexed with a unique `(gameId, userId)` key and a leaderboard sort key `(gameId, bestScore, updatedAt, _id)`; indexes are created idempotently on first use like the Vids ones.
+- The model is generic on `gameId` ("tetris" today), so adding future games is just a new client game plus a page — no schema change.
+- A light submission cooldown (`gameScoreSubmissions`) stops scripted spam; this is casual anti-abuse, not real score verification.
 
 ## Available Scripts
 

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -43,6 +43,13 @@ import {
 import { getYouTubeVideoId } from "@/lib/utils";
 import { decodeMultipartTextField } from "@/lib/form-encoding";
 import {
+    recordGameScore,
+    getGameLeaderboard,
+    canSubmitScore,
+    normalizeTetrisScore,
+    normalizePlaySeconds,
+} from "@/lib/games";
+import {
     normalizeUsername,
     validateUsername,
 } from "@/lib/usernames";
@@ -74,6 +81,10 @@ import {
     type SerializedVidComment,
     type VidFeedPage,
     VID_REPORT_CATEGORIES,
+    GAME_IDS,
+    type GameId,
+    type GameLeaderboard,
+    type GameScoreCursor,
 } from "@/lib/types";
 
 type ActionResult = { ok?: boolean; error?: string; photo?: string };
@@ -3119,4 +3130,59 @@ export async function runVidCleanupAction(): Promise<
         return { error: "Not allowed." };
     const removed = await cleanupAbandonedVids();
     return { ok: true, removed };
+}
+
+// ---------------------------------------------------------------- Games
+
+// Records a finished game score. Untrusted input (scores and play time come
+// from the client), so the server re-validates everything and keeps only the
+// player's best score for the leaderboard.
+export async function submitGameScoreAction(
+    gameId: string,
+    score: unknown,
+    playSeconds: unknown,
+): Promise<ActionResult & { isNewBest?: boolean; bestScore?: number }> {
+    const user = await requireUser();
+
+    if (!GAME_IDS.includes(gameId as GameId)) {
+        return { error: "Unknown game." };
+    }
+
+    const bestScore = normalizeTetrisScore(score);
+    if (bestScore === null) {
+        return { error: "Invalid score." };
+    }
+
+    const played = normalizePlaySeconds(playSeconds);
+    if (played === null) {
+        return { error: "Please play for a few seconds before submitting." };
+    }
+
+    const cooldown = await canSubmitScore(user._id.toString());
+    if (!cooldown.allowed) return { error: cooldown.error };
+
+    const result = await recordGameScore(
+        gameId as GameId,
+        user._id.toString(),
+        bestScore,
+    );
+
+    revalidatePath("/games");
+    return {
+        ok: true,
+        isNewBest: result.isNewBest,
+        bestScore: result.bestScore,
+    };
+}
+
+export async function getMoreGameScoresAction(
+    gameId: GameId,
+    cursor: GameScoreCursor | null,
+): Promise<GameLeaderboard> {
+    const user = await getCurrentUser();
+    return getGameLeaderboard(
+        gameId,
+        user?._id.toString() ?? null,
+        cursor,
+    );
 }

--- a/app/components/GamesLeaderboard.tsx
+++ b/app/components/GamesLeaderboard.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { useCallback, useRef, useState, useTransition } from "react";
+import Link from "next/link";
+import { getMoreGameScoresAction } from "@/app/actions";
+import type { GameLeaderboard } from "@/lib/types";
+import Box from "@/app/components/Box";
+import UserAvatar from "@/app/components/UserAvatar";
+
+export default function GamesLeaderboard({
+    initial,
+    currentUserId,
+}: {
+    initial: GameLeaderboard;
+    currentUserId?: string | null;
+}) {
+    const [leaderboard, setLeaderboard] = useState(initial);
+    const [offset, setOffset] = useState(0);
+    const [pending, startTransition] = useTransition();
+    const loadingRef = useRef(false);
+
+    const hasMore = leaderboard.nextCursor !== null;
+
+    const loadMore = useCallback(() => {
+        if (loadingRef.current || !leaderboard.nextCursor) return;
+        loadingRef.current = true;
+        startTransition(async () => {
+            try {
+                const next = await getMoreGameScoresAction(
+                    leaderboard.gameId,
+                    leaderboard.nextCursor,
+                );
+                setLeaderboard((prev) => ({
+                    gameId: next.gameId,
+                    scores: [...prev.scores, ...next.scores],
+                    nextCursor: next.nextCursor,
+                    myRank: prev.myRank,
+                    myBest: prev.myBest,
+                    myGamesPlayed: prev.myGamesPlayed,
+                }));
+                setOffset((o) => o + next.scores.length);
+            } finally {
+                loadingRef.current = false;
+            }
+        });
+    }, [leaderboard.gameId, leaderboard.nextCursor]);
+
+    return (
+        <Box title="All-Users Leaderboard">
+            {currentUserId && leaderboard.myRank !== null && (
+                <div className="mb-3 border border-[#6699cc] bg-[#fbe9f6] p-2 text-[13px]">
+                    <span className="font-bold text-[#003399]">
+                        Your rank: #{leaderboard.myRank}
+                    </span>
+                    <span className="text-[#2c4d80]">
+                        {"  ·  "}Best:{" "}
+                        {leaderboard.myBest?.toLocaleString() ?? "—"}
+                    </span>
+
+                    <span className="text-[#2c4d80]">
+                        {"  ·  "}Rounds played:{" "}
+                        {leaderboard.myGamesPlayed ?? 0}
+                    </span>
+                </div>
+            )}
+            {currentUserId && leaderboard.myRank === null && (
+                <p className="mb-3 text-[13px] text-[#2c4d80]">
+                    No scores yet — play a round to get on the board.
+                </p>
+            )}
+            {!currentUserId && (
+                <p className="mb-3 text-[13px] text-[#2c4d80]">
+                    <Link
+                        href="/login"
+                        className="text-[#003399] underline"
+                    >
+                        Log in
+                    </Link>{" "}
+                    to play and place on the ranking.
+                </p>
+            )}
+
+            {leaderboard.scores.length === 0 ? (
+                <p className="py-6 text-center text-[#2c4d80]">
+                    No high scores yet. Be the first!
+                </p>
+            ) : (
+                <ol className="flex flex-col">
+                    {leaderboard.scores.map((score, i) => {
+                        const rank = offset + i + 1;
+                        const mine = score.userId === currentUserId;
+                        return (
+                            <li
+                                key={score._id}
+                                className={`flex items-center gap-2 border-b border-[#dbe9f7] py-1.5 last:border-b-0 ${
+                                    mine ? "bg-[#fbe9f6]" : ""
+                                }`}
+                            >
+                                <span
+                                    className={`w-7 shrink-0 text-center text-[12px] font-bold ${
+                                        rank <= 3
+                                            ? "text-[#cc3399]"
+                                            : "text-[#2c4d80]"
+                                    }`}
+                                >
+                                    {rank}
+                                </span>
+                                <Link
+                                    href={`/${score.author.username}`}
+                                    className="flex min-w-0 items-center gap-2"
+                                >
+                                    <UserAvatar
+                                        src={score.author.photo}
+                                        alt={score.author.username}
+                                        cloudinaryWidth={56}
+                                        className="h-7 w-7 shrink-0 rounded-sm border border-[#6699cc] object-cover"
+                                    />
+                                    <span className="min-w-0 truncate text-[13px] font-bold text-[#003399] hover:underline">
+                                        {score.author.displayName}
+                                    </span>
+                                </Link>
+                                {mine && (
+                                    <span className="rounded-sm bg-[#cc3399] px-1.5 text-[10px] font-bold text-white">
+                                        you
+                                    </span>
+                                )}
+                                <span className="ml-auto shrink-0 text-[13px] font-bold text-black">
+                                    {score.bestScore.toLocaleString()}
+                                </span>
+                            </li>
+                        );
+                    })}
+                </ol>
+            )}
+
+            {hasMore && (
+                <button
+                    type="button"
+                    className="btn mt-3 w-full"
+                    onClick={loadMore}
+                    disabled={pending}
+                >
+                    {pending ? "Loading..." : "More scores"}
+                </button>
+            )}
+        </Box>
+    );
+}

--- a/app/components/NavBar.tsx
+++ b/app/components/NavBar.tsx
@@ -127,6 +127,7 @@ export default function NavBar({
                                 <NavLink href="/chatboxes">Chatbox</NavLink>
                                 <NavLink href="/groups">Groups</NavLink>
                                 <NavLink href="/vids">Vids</NavLink>
+                                <NavLink href="/games">Games</NavLink>
                                 <NavLink href="/search">Search</NavLink>
                                 <NavLink
                                     href="/notifications"

--- a/app/components/TetrisGame.tsx
+++ b/app/components/TetrisGame.tsx
@@ -1,0 +1,444 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import {
+    TETRIS_COLS,
+    TETRIS_ROWS,
+    TETROMINO_SHAPES,
+    TETROMINO_TYPES,
+    createEmptyBoard,
+    createInitialState,
+    gravityMs,
+    hardDrop,
+    movePiece,
+    resolveBoard,
+    rotatePiece,
+    stepGame,
+    type TetrisState,
+    type TetrominoType,
+} from "@/lib/tetris";
+import { submitGameScoreAction } from "@/app/actions";
+
+type Phase = "idle" | "playing" | "paused" | "over";
+
+function shuffle<T>(items: T[], rand: () => number): T[] {
+    const copy = [...items];
+    for (let i = copy.length - 1; i > 0; i--) {
+        const j = Math.floor(rand() * (i + 1));
+        [copy[i], copy[j]] = [copy[j], copy[i]];
+    }
+    return copy;
+}
+
+export default function TetrisGame({ isLoggedIn }: { isLoggedIn: boolean }) {
+    const router = useRouter();
+
+    const [game, setGame] = useState<TetrisState | null>(null);
+    const [phase, setPhase] = useState<Phase>("idle");
+    const [submitResult, setSubmitResult] = useState("");
+    const [submitting, setSubmitting] = useState(false);
+
+    // Refs mirror the React state so event handlers and effects can act on the
+    // latest values synchronously. They are never read during render.
+    const gameRef = useRef<TetrisState | null>(null);
+    const phaseRef = useRef<Phase>("idle");
+    const bagRef = useRef<TetrominoType[]>([]);
+    const playedMsRef = useRef(0);
+    const runStartRef = useRef(0);
+    const submittedRef = useRef(false);
+
+    const setPhaseBoth = useCallback((next: Phase) => {
+        phaseRef.current = next;
+        setPhase(next);
+    }, []);
+
+    // Draws pieces from a shuffled 7-bag so every seven pieces contain one of
+    // each shape (standard Tetris distribution).
+    const sample = useCallback((): TetrominoType => {
+        if (bagRef.current.length === 0) {
+            bagRef.current = shuffle([...TETROMINO_TYPES], Math.random);
+        }
+        return bagRef.current.pop() as TetrominoType;
+    }, []);
+
+    const submitScore = useCallback(
+        async (score: number, playedSeconds: number) => {
+            setSubmitting(true);
+            try {
+                const res = await submitGameScoreAction(
+                    "tetris",
+                    score,
+                    playedSeconds,
+                );
+                if (res.ok) {
+                    setSubmitResult(
+                        res.isNewBest
+                            ? "New high score! It made the leaderboard."
+                            : "Score recorded. Not your best yet.",
+                    );
+                    router.refresh();
+                } else if (res.error) {
+                    setSubmitResult(`Couldn't save your score: ${res.error}`);
+                }
+            } catch {
+                setSubmitResult("Couldn't save your score.");
+            } finally {
+                setSubmitting(false);
+            }
+        },
+        [router],
+    );
+
+    // Applies an engine result: stores it, and when the well tops out, ends
+    // the game and submits the final score once.
+    const commit = useCallback(
+        (next: TetrisState) => {
+            gameRef.current = next;
+            setGame(next);
+            if (next.over && !submittedRef.current && isLoggedIn) {
+                submittedRef.current = true;
+                setPhaseBoth("over");
+                playedMsRef.current += Date.now() - runStartRef.current;
+                const playedSeconds = Math.max(
+                    1,
+                    Math.round(playedMsRef.current / 1000),
+                );
+                void submitScore(next.score, playedSeconds);
+            }
+        },
+        [setPhaseBoth, submitScore, isLoggedIn],
+    );
+
+    const start = useCallback(() => {
+        submittedRef.current = false;
+        playedMsRef.current = 0;
+        runStartRef.current = Date.now();
+        setSubmitResult("");
+        commit(createInitialState(sample));
+        setPhaseBoth("playing");
+    }, [sample, commit, setPhaseBoth]);
+
+    const togglePause = useCallback(() => {
+        if (phaseRef.current === "playing") {
+            playedMsRef.current += Date.now() - runStartRef.current;
+            setPhaseBoth("paused");
+        } else if (phaseRef.current === "paused") {
+            runStartRef.current = Date.now();
+            setPhaseBoth("playing");
+        }
+    }, [setPhaseBoth]);
+
+    const move = useCallback(
+        (dx: number, dy: number) => {
+            const prev = gameRef.current;
+            if (!prev || phaseRef.current !== "playing") return;
+            commit(movePiece(prev, dx, dy));
+        },
+        [commit],
+    );
+
+    const rotate = useCallback(() => {
+        const prev = gameRef.current;
+        if (!prev || phaseRef.current !== "playing") return;
+        commit(rotatePiece(prev));
+    }, [commit]);
+
+    const dropHard = useCallback(() => {
+        const prev = gameRef.current;
+        if (!prev || phaseRef.current !== "playing") return;
+        commit(hardDrop(prev, sample));
+    }, [commit, sample]);
+
+    const handleKey = useCallback(
+        (event: KeyboardEvent) => {
+            const actionKeys = new Set([
+                "ArrowLeft",
+                "ArrowRight",
+                "ArrowDown",
+                "ArrowUp",
+                " ",
+            ]);
+            if (actionKeys.has(event.key)) event.preventDefault();
+
+            if (phaseRef.current === "idle") {
+                if (actionKeys.has(event.key) || event.key === "Enter") {
+                    start();
+                }
+                return;
+            }
+
+            if (phaseRef.current === "over") {
+                if (
+                    event.key === " " ||
+                    event.key === "Enter" ||
+                    event.key.toLowerCase() === "r"
+                ) {
+                    start();
+                }
+                return;
+            }
+
+            if (phaseRef.current === "paused") {
+                if (event.key.toLowerCase() === "p") togglePause();
+                return;
+            }
+
+            switch (event.key) {
+                case "ArrowLeft":
+                    move(-1, 0);
+                    break;
+                case "ArrowRight":
+                    move(1, 0);
+                    break;
+                case "ArrowDown":
+                    move(0, 1);
+                    break;
+                case "ArrowUp":
+                case "x":
+                case "X":
+                    rotate();
+                    break;
+                case " ":
+                    dropHard();
+                    break;
+                case "p":
+                case "P":
+                    togglePause();
+                    break;
+                default:
+                    break;
+            }
+        },
+        [start, togglePause, move, rotate, dropHard],
+    );
+
+    useEffect(() => {
+        const handler = (event: KeyboardEvent) => handleKey(event);
+        window.addEventListener("keydown", handler);
+        return () => window.removeEventListener("keydown", handler);
+    }, [handleKey]);
+
+    const level = game?.level ?? 1;
+    const running = phase === "playing";
+
+    // Gravity loop; re-created when the player starts/pauses or levels up.
+    useEffect(() => {
+        if (!running) return;
+        const id = window.setInterval(() => {
+            const prev = gameRef.current;
+            if (prev && !prev.over) commit(stepGame(prev, sample));
+        }, gravityMs(level));
+        return () => window.clearInterval(id);
+    }, [running, level, commit, sample]);
+
+    const board = game ? resolveBoard(game) : createEmptyBoard();
+    const nextType = game?.next ?? null;
+    const score = game?.score ?? 0;
+    const lines = game?.lines ?? 0;
+
+    return (
+        <div className="box">
+            <div className="box-title" style={{ background: "#2c4d80" }}>
+                Tetris
+            </div>
+            <div className="box-content flex flex-col items-center gap-3 md:flex-row md:items-start md:justify-center">
+                <div className="relative">
+                    <div
+                        className="tetris-board"
+                        style={{
+                            display: "grid",
+                            gridTemplateColumns: `repeat(${TETRIS_COLS}, 1fr)`,
+                            gridTemplateRows: `repeat(${TETRIS_ROWS}, 1fr)`,
+                        }}
+                    >
+                        {board.map((row, y) =>
+                            row.map((cell, x) => (
+                                <div
+                                    key={`${y}-${x}`}
+                                    className={`tetris-cell${cell ? " tetris-cell--filled" : ""}`}
+                                    data-type={cell ?? ""}
+                                />
+                            )),
+                        )}
+                    </div>
+
+                    {phase === "idle" && game === null && (
+                        <div className="tetris-overlay">
+                            <div className="tetris-overlay-title">TETRIS</div>
+                            <p>Press any arrow key to start.</p>
+                            {!isLoggedIn && (
+                                <p className="tetris-overlay-hint">
+                                    Log in to save your score.
+                                </p>
+                            )}
+                            <button
+                                type="button"
+                                className="btn"
+                                onClick={start}
+                            >
+                                Start Game
+                            </button>
+                        </div>
+                    )}
+
+                    {phase === "paused" && (
+                        <div className="tetris-overlay">
+                            <div className="tetris-overlay-title">Paused</div>
+                            <p>Press P to resume.</p>
+                            <button
+                                type="button"
+                                className="btn"
+                                onClick={togglePause}
+                            >
+                                Resume
+                            </button>
+                        </div>
+                    )}
+
+                    {phase === "over" && (
+                        <div className="tetris-overlay">
+                            <div className="tetris-overlay-title">Game Over</div>
+                            <p>Score: {score}</p>
+                            <button
+                                type="button"
+                                className="btn"
+                                onClick={start}
+                                disabled={submitting}
+                            >
+                                Play Again
+                            </button>
+                        </div>
+                    )}
+                </div>
+
+                <div className="flex w-full flex-col gap-3 md:w-[170px]">
+                    <div className="tetris-panel">
+                        <div className="tetris-panel-label">Score</div>
+                        <div className="tetris-panel-value">{score}</div>
+                    </div>
+                    <div className="tetris-panel">
+                        <div className="tetris-panel-label">Lines</div>
+                        <div className="tetris-panel-value">{lines}</div>
+                    </div>
+                    <div className="tetris-panel">
+                        <div className="tetris-panel-label">Level</div>
+                        <div className="tetris-panel-value">{level}</div>
+                    </div>
+                    <div className="tetris-panel">
+                        <div className="tetris-panel-label">Next</div>
+                        <div className="mt-1 flex justify-center">
+                            <div
+                                className="tetris-preview"
+                                style={{
+                                    display: "grid",
+                                    gridTemplateColumns:
+                                        "repeat(4, minmax(0, 1fr))",
+                                }}
+                            >
+                                {Array.from({ length: 16 }, (_, i) => {
+                                    const r = Math.floor(i / 4);
+                                    const c = i % 4;
+                                    const shape = nextType
+                                        ? TETROMINO_SHAPES[nextType]
+                                        : [];
+                                    const filled = shape[r]?.[c];
+                                    return (
+                                        <div
+                                            key={i}
+                                            className={`tetris-cell tetris-cell--preview${filled ? " tetris-cell--filled" : ""}`}
+                                            data-type={filled ? nextType : ""}
+                                        />
+                                    );
+                                })}
+                            </div>
+                        </div>
+                    </div>
+
+                    {(phase === "playing" || phase === "paused") && (
+                        <div className="tetris-controls">
+                            <button
+                                type="button"
+                                className="btn btn-ghost"
+                                onClick={togglePause}
+                            >
+                                {phase === "playing" ? "Pause" : "Resume"}
+                            </button>
+                        </div>
+                    )}
+
+                    <div className="tetris-controls">
+                        <button
+                            type="button"
+                            className="btn btn-ghost"
+                            onClick={() => move(-1, 0)}
+                            aria-label="Move left"
+                            disabled={phase !== "playing"}
+                        >
+                            ←
+                        </button>
+                        <button
+                            type="button"
+                            className="btn btn-ghost"
+                            onClick={rotate}
+                            aria-label="Rotate"
+                            disabled={phase !== "playing"}
+                        >
+                            ↻
+                        </button>
+                        <button
+                            type="button"
+                            className="btn btn-ghost"
+                            onClick={() => move(1, 0)}
+                            aria-label="Move right"
+                            disabled={phase !== "playing"}
+                        >
+                            →
+                        </button>
+                        <button
+                            type="button"
+                            className="btn btn-ghost"
+                            onClick={() => move(0, 1)}
+                            aria-label="Soft drop"
+                            disabled={phase !== "playing"}
+                        >
+                            ↓
+                        </button>
+                        <button
+                            type="button"
+                            className="btn btn-ghost"
+                            onClick={dropHard}
+                            aria-label="Hard drop"
+                            disabled={phase !== "playing"}
+                        >
+                            ⤓
+                        </button>
+                    </div>
+
+                    {submitting && (
+                        <p className="tetris-caption">Saving your score...</p>
+                    )}
+                    {submitResult && (
+                        <p className="tetris-caption">{submitResult}</p>
+                    )}
+                    {isLoggedIn && phase === "idle" && (
+                        <p className="tetris-caption">
+                            Score clears register on the all-users leaderboard.
+                        </p>
+                    )}
+                    {!isLoggedIn && (
+                        <p className="tetris-caption">
+                            <Link href="/login" className="no-underline">
+                                <span className="text-[#003399] underline">
+                                    Log in
+                                </span>
+                            </Link>{" "}
+                            to play for the leaderboard.
+                        </p>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/app/games/page.tsx
+++ b/app/games/page.tsx
@@ -1,0 +1,35 @@
+import type { Metadata } from "next";
+import { getCurrentUser } from "@/lib/auth";
+import { getGameLeaderboard } from "@/lib/games";
+import TetrisGame from "@/app/components/TetrisGame";
+import GamesLeaderboard from "@/app/components/GamesLeaderboard";
+
+export const metadata: Metadata = {
+    title: "Games",
+    description:
+        "Play casual games on Genggi and climb the all-users leaderboard.",
+};
+
+export default async function GamesPage() {
+    const user = await getCurrentUser();
+    const viewerId = user?._id.toString() ?? null;
+    const leaderboard = await getGameLeaderboard("tetris", viewerId, null);
+
+    return (
+        <div className="games-page mx-auto max-w-[960px] p-2 sm:p-3">
+            <div className="mb-3">
+                <h1 className="text-2xl font-bold text-[#003399]">Games</h1>
+                <p className="text-sm text-[#2c4d80]">
+                    Stack blocks, clear lines, and climb the all-users ranking.
+                </p>
+            </div>
+            <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_360px]">
+                <TetrisGame isLoggedIn={!!user} />
+                <GamesLeaderboard
+                    initial={leaderboard}
+                    currentUserId={viewerId}
+                />
+            </div>
+        </div>
+    );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -577,6 +577,124 @@ select {
     }
 }
 
+/* Games / Tetris */
+.tetris-board {
+    width: min(260px, 72vw);
+    aspect-ratio: 1 / 2;
+    position: relative;
+    overflow: hidden;
+    border: 2px solid #2c4d80;
+    background: #0d1b2e;
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+}
+.tetris-board .tetris-cell {
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    background: rgba(255, 255, 255, 0.03);
+}
+.tetris-cell {
+    width: 100%;
+    height: 100%;
+    box-sizing: border-box;
+}
+.tetris-cell--filled {
+    border-color: transparent;
+    box-shadow:
+        inset 0 0 0 1px rgba(0, 0, 0, 0.35),
+        inset 0 0 6px rgba(255, 255, 255, 0.35);
+}
+.tetris-cell--preview {
+    background: transparent;
+}
+.tetris-cell[data-type="I"] {
+    background: #00e4e4;
+}
+.tetris-cell[data-type="O"] {
+    background: #e4e400;
+}
+.tetris-cell[data-type="T"] {
+    background: #a555e4;
+}
+.tetris-cell[data-type="S"] {
+    background: #00cc33;
+}
+.tetris-cell[data-type="Z"] {
+    background: #e40000;
+}
+.tetris-cell[data-type="J"] {
+    background: #3366ff;
+}
+.tetris-cell[data-type="L"] {
+    background: #ffa500;
+}
+.tetris-overlay {
+    position: absolute;
+    z-index: 5;
+    inset: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    padding: 8px;
+    text-align: center;
+    color: #ffffff;
+    background: rgba(13, 27, 46, 0.88);
+}
+.tetris-overlay-title {
+    font-size: 22px;
+    font-weight: 800;
+    letter-spacing: 0.08em;
+    color: #ffe14d;
+}
+.tetris-overlay p {
+    margin: 0;
+    font-size: 12px;
+    color: #dbe9f7;
+}
+.tetris-overlay-hint {
+    font-size: 11px !important;
+    color: #ff9db8 !important;
+}
+.tetris-panel {
+    border: 1px solid #6699cc;
+    background: #f5f9ff;
+    padding: 6px 10px;
+    text-align: center;
+}
+.tetris-panel-label {
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    color: #2c4d80;
+    text-transform: uppercase;
+}
+.tetris-panel-value {
+    font-size: 22px;
+    font-weight: 800;
+    color: #003399;
+}
+.tetris-preview {
+    width: 72px;
+    aspect-ratio: 1 / 1;
+    border: 1px solid #6699cc;
+    background: #0d1b2e;
+}
+.tetris-controls {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    justify-content: center;
+}
+.tetris-controls .btn {
+    min-width: 40px;
+}
+.tetris-caption {
+    margin: 0;
+    font-size: 11px;
+    text-align: center;
+    color: #2c4d80;
+}
+
 :root {
     --background: oklch(1 0 0);
     --foreground: oklch(0.145 0 0);

--- a/lib/games.test.ts
+++ b/lib/games.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import {
+    GAME_MAX_SCORE,
+    GAME_MIN_PLAY_SECONDS,
+    normalizePlaySeconds,
+    normalizeTetrisScore,
+    parseGameScoreCursor,
+} from "./games";
+
+describe("normalizeTetrisScore", () => {
+    it("accepts integer scores in range", () => {
+        expect(normalizeTetrisScore(0)).toBe(0);
+        expect(normalizeTetrisScore(100)).toBe(100);
+        expect(normalizeTetrisScore(GAME_MAX_SCORE)).toBe(GAME_MAX_SCORE);
+    });
+
+    it("rejects out-of-range and non-integer values", () => {
+        expect(normalizeTetrisScore(-1)).toBeNull();
+        expect(normalizeTetrisScore(GAME_MAX_SCORE + 1)).toBeNull();
+        expect(normalizeTetrisScore(12.5)).toBeNull();
+        expect(normalizeTetrisScore(Number.NaN)).toBeNull();
+        expect(normalizeTetrisScore(Number.POSITIVE_INFINITY)).toBeNull();
+        expect(normalizeTetrisScore("100")).toBeNull();
+        expect(normalizeTetrisScore(null)).toBeNull();
+        expect(normalizeTetrisScore(undefined)).toBeNull();
+    });
+});
+
+describe("normalizePlaySeconds", () => {
+    it("accepts play times at or above the minimum", () => {
+        expect(normalizePlaySeconds(GAME_MIN_PLAY_SECONDS)).toBe(
+            GAME_MIN_PLAY_SECONDS,
+        );
+        expect(normalizePlaySeconds(60)).toBe(60);
+    });
+
+    it("rejects played-too-fast and garbage input", () => {
+        expect(normalizePlaySeconds(GAME_MIN_PLAY_SECONDS - 1)).toBeNull();
+        expect(normalizePlaySeconds(0)).toBeNull();
+        expect(normalizePlaySeconds(-3)).toBeNull();
+        expect(normalizePlaySeconds("10")).toBeNull();
+        expect(normalizePlaySeconds(undefined)).toBeNull();
+        expect(normalizePlaySeconds(Number.NaN)).toBeNull();
+    });
+
+    it("caps absurd play times", () => {
+        expect(normalizePlaySeconds(999999)).toBe(3600);
+    });
+});
+
+describe("parseGameScoreCursor", () => {
+    it("parses a valid cursor", () => {
+        const oid = "507f1f77bcf86cd799439011";
+        const cursor = parseGameScoreCursor({
+            bestScore: 1200,
+            updatedAt: "2026-01-01T00:00:00.000Z",
+            _id: oid,
+        });
+        expect(cursor).not.toBeNull();
+        expect(cursor!.bestScore).toBe(1200);
+        expect(cursor!._id).toBe(oid);
+    });
+
+    it("returns null for null/undefined/malformed cursors", () => {
+        expect(parseGameScoreCursor(null)).toBeNull();
+        expect(parseGameScoreCursor(undefined)).toBeNull();
+        expect(
+            parseGameScoreCursor({
+                bestScore: Number.NaN,
+                updatedAt: "2026-01-01T00:00:00.000Z",
+                _id: "507f1f77bcf86cd799439011",
+            }),
+        ).toBeNull();
+        expect(
+            parseGameScoreCursor({
+                bestScore: 1200,
+                updatedAt: "not-a-date",
+                _id: "507f1f77bcf86cd799439011",
+            }),
+        ).toBeNull();
+        expect(
+            parseGameScoreCursor({
+                bestScore: 1200,
+                updatedAt: "2026-01-01T00:00:00.000Z",
+                _id: "not-an-object-id",
+            }),
+        ).toBeNull();
+    });
+});

--- a/lib/games.ts
+++ b/lib/games.ts
@@ -1,0 +1,336 @@
+import { getDb, ObjectId } from "@/lib/db";
+import type {
+  GameId,
+  GameLeaderboard,
+  GameScore,
+  GameScoreAuthorCard,
+  GameScoreCursor,
+  SerializedGameScore,
+} from "@/lib/types";
+
+export const GAMES_LEADERBOARD_PAGE_SIZE = 25;
+export const GAME_MAX_SCORE = 9_999_999;
+// Server-enforced minimum a player must have "played" before a score counts.
+// The client reports play time; this is a casual anti-abuse floor, not real
+// protection against a crafted request.
+export const GAME_MIN_PLAY_SECONDS = 5;
+// Minimum gap between submissions from the same user, so a script cannot spam
+// thousands of cheap submissions per hour into the gamesPlayed counter.
+export const GAME_SUBMISSION_COOLDOWN_MS = 3_000;
+
+export const GAMES_SCORE_COLLECTION = "gameScores";
+export const GAMES_RATE_LIMIT_COLLECTION = "gameScoreSubmissions";
+
+// ------------------------------------------------------------ Pure helpers
+
+// Parses a Strict mode integer score from untrusted input. Returns null for
+// anything out of range rather than throwing.
+export function normalizeTetrisScore(input: unknown): number | null {
+  if (typeof input !== "number" || !Number.isFinite(input)) return null;
+  if (!Number.isInteger(input) || input < 0 || input > GAME_MAX_SCORE) {
+    return null;
+  }
+  return input;
+}
+
+// Parses a defensively shaped play-time value from the client.
+export function normalizePlaySeconds(input: unknown): number | null {
+  if (typeof input !== "number" || !Number.isFinite(input)) return null;
+  if (input < GAME_MIN_PLAY_SECONDS) return null;
+  return Math.min(input, 3600);
+}
+
+export function parseGameScoreCursor(
+  cursor: GameScoreCursor | null | undefined,
+): GameScoreCursor | null {
+  if (!cursor) return null;
+  if (!Number.isFinite(cursor.bestScore)) return null;
+  const updatedAt = new Date(cursor.updatedAt);
+  if (Number.isNaN(updatedAt.getTime())) return null;
+  try {
+    new ObjectId(cursor._id);
+  } catch {
+    return null;
+  }
+  return cursor;
+}
+
+// ---------------------------------------------------------------- Indexes
+
+let indexesEnsured = false;
+
+// Idempotent index setup, mirroring ensureVidIndexes. Runs once per process.
+export async function ensureGameIndexes(): Promise<void> {
+  if (indexesEnsured) return;
+  const db = getDb();
+  await Promise.all([
+    db
+      .collection(GAMES_SCORE_COLLECTION)
+      .createIndex({ gameId: 1, userId: 1 }, { unique: true }),
+    // Leaderboard sort: best score desc, then earliest-to-reach asc, then _id.
+    db
+      .collection(GAMES_SCORE_COLLECTION)
+      .createIndex({ gameId: 1, bestScore: -1, updatedAt: 1, _id: 1 }),
+    db
+      .collection(GAMES_RATE_LIMIT_COLLECTION)
+      .createIndex({ userId: 1, createdAt: -1 }),
+  ]);
+  indexesEnsured = true;
+}
+
+// ------------------------------------------------------------ Score writing
+
+export interface RecordScoreResult {
+  isNewBest: boolean;
+  bestScore: number;
+  gamesPlayed: number;
+}
+
+// Records a finished game. Keeps one document per (gameId, userId) updated to
+// the player's best score; this is the document the leaderboard ranks by.
+export async function recordGameScore(
+  gameId: GameId,
+  userId: string,
+  score: number,
+): Promise<RecordScoreResult> {
+  await ensureGameIndexes();
+  const db = getDb();
+  const oid = new ObjectId(userId);
+  const now = new Date();
+
+  const existing = (await db
+    .collection(GAMES_SCORE_COLLECTION)
+    .findOne({ gameId, userId: oid })) as unknown as GameScore | null;
+
+  if (!existing) {
+    try {
+      await db.collection(GAMES_SCORE_COLLECTION).insertOne({
+        gameId,
+        userId: oid,
+        bestScore: score,
+        gamesPlayed: 1,
+        createdAt: now,
+        updatedAt: now,
+      });
+      return { isNewBest: true, bestScore: score, gamesPlayed: 1 };
+    } catch (error) {
+      // Lost the race to another insert (unique index). Fall through to the
+      // update path below.
+      if ((error as { code?: number }).code !== 11000) throw error;
+    }
+  }
+
+  const current = existing ?? (await db
+    .collection(GAMES_SCORE_COLLECTION)
+    .findOne({ gameId, userId: oid })) as unknown as GameScore | null;
+
+  if (!current) throw new Error("Failed to load game score.");
+  const isNewBest = score > current.bestScore;
+
+  await db.collection(GAMES_SCORE_COLLECTION).updateOne(
+    { gameId, userId: oid },
+    {
+      $inc: { gamesPlayed: 1 },
+      ...(isNewBest
+        ? { $set: { bestScore: score, updatedAt: now } }
+        : {}),
+    },
+  );
+
+  return {
+    isNewBest,
+    bestScore: Math.max(current.bestScore, score),
+    gamesPlayed: current.gamesPlayed + 1,
+  };
+}
+
+// Casual anti-abuse cooldown: lets through the many legitimate rapid-fire
+// submissions and rejects only tight scripted loops.
+export async function canSubmitScore(userId: string): Promise<{
+  allowed: boolean;
+  error?: string;
+}> {
+  const db = getDb();
+  const latest = (await db
+    .collection(GAMES_RATE_LIMIT_COLLECTION)
+    .findOne(
+      { userId: new ObjectId(userId) },
+      { sort: { createdAt: -1 }, projection: { createdAt: 1 } },
+    )) as unknown as { createdAt: Date } | null;
+
+  if (latest && Date.now() - latest.createdAt.getTime() < GAME_SUBMISSION_COOLDOWN_MS) {
+    return {
+      allowed: false,
+      error: "Whoa, slow down! Take a breath before your next round.",
+    };
+  }
+
+  await db.collection(GAMES_RATE_LIMIT_COLLECTION).insertOne({
+    userId: new ObjectId(userId),
+    createdAt: new Date(),
+  });
+  return { allowed: true };
+}
+
+// ------------------------------------------------------------- Leaderboard
+
+function toGameScoreAuthorCard(author: {
+  _id: ObjectId;
+  username: string;
+  displayName: string;
+  photo: string | null;
+}): GameScoreAuthorCard {
+  return {
+    _id: author._id.toString(),
+    username: author.username,
+    displayName: author.displayName,
+    photo: author.photo,
+  };
+}
+
+function toSerializedGameScore(
+  score: GameScore,
+  author: GameScoreAuthorCard,
+): SerializedGameScore {
+  return {
+    _id: score._id.toString(),
+    gameId: score.gameId,
+    userId: score.userId.toString(),
+    bestScore: score.bestScore,
+    gamesPlayed: score.gamesPlayed,
+    createdAt: score.createdAt.toISOString(),
+    updatedAt: score.updatedAt.toISOString(),
+    author,
+  };
+}
+
+// 1-based rank of the viewer's best score for a game. Ties are broken by the
+// same rule as the leaderboard sort: the player who reached the score first
+// (earlier updatedAt) places higher.
+async function rankOfScore(
+  gameId: GameId,
+  score: GameScore,
+): Promise<number> {
+  const db = getDb();
+  const higher = await db.collection(GAMES_SCORE_COLLECTION).countDocuments({
+    gameId,
+    $or: [
+      { bestScore: { $gt: score.bestScore } },
+      {
+        bestScore: score.bestScore,
+        updatedAt: { $lt: score.updatedAt },
+      },
+    ],
+  });
+  return higher + 1;
+}
+
+// Top scores for a game plus the viewer's own statistics. Cursor-based like
+// the vids feed: rows sort by bestScore desc, updatedAt asc, _id asc. The
+// viewer stats are only computed for the first page (cursor null) — paging
+// keeps the rank the client already knew, consistent with the feed pattern.
+export async function getGameLeaderboard(
+  gameId: GameId,
+  viewerId: string | null,
+  cursor: GameScoreCursor | null | undefined,
+  limit = GAMES_LEADERBOARD_PAGE_SIZE,
+): Promise<GameLeaderboard> {
+  await ensureGameIndexes();
+  const db = getDb();
+  const parsed = parseGameScoreCursor(cursor);
+
+  const query: Record<string, unknown> = { gameId };
+  if (parsed) {
+    query.$or = [
+      { bestScore: { $lt: parsed.bestScore } },
+      {
+        bestScore: parsed.bestScore,
+        $or: [
+          { updatedAt: { $gt: new Date(parsed.updatedAt) } },
+          {
+            updatedAt: new Date(parsed.updatedAt),
+            _id: { $gt: new ObjectId(parsed._id) },
+          },
+        ],
+      },
+    ];
+  }
+
+  const rawScores = (await db
+    .collection(GAMES_SCORE_COLLECTION)
+    .find(query)
+    .sort({ bestScore: -1, updatedAt: 1, _id: 1 })
+    .limit(limit + 1)
+    .toArray()) as unknown as GameScore[];
+
+  const hasMore = rawScores.length > limit;
+  const scores = rawScores.slice(0, limit);
+
+  let myRank: number | null = null;
+  let myBest: number | null = null;
+  let myGamesPlayed: number | null = null;
+
+  let viewerScore: GameScore | null = null;
+  if (viewerId && !cursor) {
+    viewerScore = (await db
+      .collection(GAMES_SCORE_COLLECTION)
+      .findOne({
+        gameId,
+        userId: new ObjectId(viewerId),
+      })) as unknown as GameScore | null;
+  }
+
+  if (viewerScore) {
+    myBest = viewerScore.bestScore;
+    myGamesPlayed = viewerScore.gamesPlayed;
+    myRank = await rankOfScore(gameId, viewerScore);
+  }
+
+  if (scores.length === 0) {
+    return {
+      gameId,
+      scores: [],
+      nextCursor: null,
+      myRank,
+      myBest,
+      myGamesPlayed,
+    };
+  }
+
+  const userIds = [
+    ...new Map(scores.map((s) => [s.userId.toString(), s.userId])).values(),
+  ];
+  const authors = (await db
+    .collection("users")
+    .find({ _id: { $in: userIds } })
+    .project({ _id: 1, username: 1, displayName: 1, photo: 1 })
+    .toArray()) as unknown as {
+    _id: ObjectId;
+    username: string;
+    displayName: string;
+    photo: string | null;
+  }[];
+  const authorById = new Map(authors.map((a) => [a._id.toString(), a]));
+
+  const last = scores[scores.length - 1];
+  const nextCursor: GameScoreCursor | null = hasMore
+    ? {
+        bestScore: last.bestScore,
+        updatedAt: last.updatedAt.toISOString(),
+        _id: last._id.toString(),
+      }
+    : null;
+
+  return {
+    gameId,
+    scores: scores.flatMap((score) => {
+      const author = authorById.get(score.userId.toString());
+      if (!author) return [];
+      return [toSerializedGameScore(score, toGameScoreAuthorCard(author))];
+    }),
+    nextCursor,
+    myRank,
+    myBest,
+    myGamesPlayed,
+  };
+}

--- a/lib/tetris.test.ts
+++ b/lib/tetris.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, it } from "vitest";
+import {
+    TETRIS_COLS,
+    TETRIS_ROWS,
+    TETROMINO_SHAPES,
+    clearFullLines,
+    collides,
+    createEmptyBoard,
+    createInitialState,
+    gravityMs,
+    hardDrop,
+    levelForLines,
+    lockPiece,
+    movePiece,
+    resolveBoard,
+    rotateCW,
+    rotatePiece,
+    scoreForLines,
+    spawnPiece,
+    stepGame,
+    type TetrisState,
+    type TetrominoType,
+} from "./tetris";
+
+const SAMPLE: () => TetrominoType = () => "I";
+
+describe("createEmptyBoard", () => {
+    it("builds a ROWS x COLS grid of nulls", () => {
+        const board = createEmptyBoard();
+        expect(board).toHaveLength(TETRIS_ROWS);
+        for (const row of board) {
+            expect(row).toHaveLength(TETRIS_COLS);
+            expect(row.every((cell) => cell === null)).toBe(true);
+        }
+    });
+});
+
+describe("rotateCW", () => {
+    it("rotates the I tetromino horizontal -> vertical", () => {
+        const rotated = rotateCW(TETROMINO_SHAPES.I);
+        expect(rotated[0]).toEqual([0, 0, 1, 0]);
+        expect(rotated[1]).toEqual([0, 0, 1, 0]);
+        expect(rotated[2]).toEqual([0, 0, 1, 0]);
+        expect(rotated[3]).toEqual([0, 0, 1, 0]);
+    });
+
+    it("is a no-op for the O tetromino", () => {
+        expect(rotateCW(TETROMINO_SHAPES.O)).toEqual(TETROMINO_SHAPES.O);
+    });
+});
+
+describe("spawnPiece", () => {
+    it("centers 3-wide pieces", () => {
+        for (const type of ["T", "S", "Z", "J", "L"] as const) {
+            const piece = spawnPiece(type);
+            expect(piece.x).toBe(Math.floor((TETRIS_COLS - 3) / 2));
+        }
+    });
+});
+
+describe("collides", () => {
+    it("rejects pieces past the walls and floor", () => {
+        const board = createEmptyBoard();
+        const shape = TETROMINO_SHAPES.T;
+        expect(collides(board, shape, -1, 0)).toBe(true);
+        expect(collides(board, shape, TETRIS_COLS - 1, 0)).toBe(true);
+        expect(collides(board, shape, 3, TETRIS_ROWS - 1)).toBe(true);
+    });
+
+    it("accepts spawn rows above the board", () => {
+        const board = createEmptyBoard();
+        expect(collides(board, TETROMINO_SHAPES.I, 3, -1)).toBe(false);
+    });
+
+    it("detects overlap with stacked blocks", () => {
+        const board = createEmptyBoard();
+        board[8][4] = "T";
+        expect(collides(board, TETROMINO_SHAPES.T, 3, 8)).toBe(true);
+        expect(collides(board, TETROMINO_SHAPES.T, 3, 6)).toBe(false);
+    });
+});
+
+describe("clearFullLines", () => {
+    it("removes full rows and shifts the rest to the bottom", () => {
+        const board = createEmptyBoard();
+        board[18] = board[18].map(() => "I" as const);
+        board[19] = board[19].map(() => "O" as const);
+        board[17][5] = "T";
+        const { board: result, cleared } = clearFullLines(board);
+        expect(cleared).toBe(2);
+        expect(result[19][5]).toBe("T");
+        expect(result[18][5]).toBe(null);
+        expect(result[0].every((cell) => cell === null)).toBe(true);
+    });
+
+    it("clears nothing on empty/partial boards", () => {
+        const board = createEmptyBoard();
+        board[0][0] = "J";
+        const { board: result, cleared } = clearFullLines(board);
+        expect(cleared).toBe(0);
+        expect(result[0][0]).toBe("J");
+    });
+});
+
+describe("scoreForLines / levelForLines / gravityMs", () => {
+    it("scores classic multipliers", () => {
+        expect(scoreForLines(0, 1)).toBe(0);
+        expect(scoreForLines(1, 1)).toBe(100);
+        expect(scoreForLines(2, 1)).toBe(300);
+        expect(scoreForLines(3, 1)).toBe(500);
+        expect(scoreForLines(4, 1)).toBe(800);
+        expect(scoreForLines(1, 5)).toBe(500);
+    });
+
+    it("levels up every 10 lines", () => {
+        expect(levelForLines(0)).toBe(1);
+        expect(levelForLines(9)).toBe(1);
+        expect(levelForLines(10)).toBe(2);
+        expect(levelForLines(42)).toBe(5);
+    });
+
+    it("speeds up as levels rise, floored at 100ms", () => {
+        expect(gravityMs(1)).toBe(800);
+        expect(gravityMs(2)).toBe(730);
+        expect(gravityMs(20)).toBe(100);
+    });
+});
+
+describe("movePiece", () => {
+    it("moves within bounds and refuses to leave them", () => {
+        const state = createInitialState(SAMPLE);
+        const left = movePiece(state, -1, 0);
+        expect(left.active!.x).toBe(state.active!.x - 1);
+
+        const wall = movePiece(state, -10, 0);
+        expect(wall).toEqual(state);
+    });
+});
+
+describe("rotatePiece", () => {
+    it("rotates and applies a wall kick", () => {
+        const state = createInitialState(() => "I");
+        const rotated = rotatePiece(state);
+        expect(rotated.active!.shape[0]).toEqual([0, 0, 1, 0]);
+    });
+});
+
+describe("stepGame", () => {
+    it("falls one row per tick", () => {
+        const state = createInitialState(SAMPLE);
+        const stepped = stepGame(state, SAMPLE);
+        expect(stepped.active!.y).toBe(state.active!.y + 1);
+    });
+
+    it("locks at the floor, scores nothing, and spawns the next piece", () => {
+        const state = createInitialState(SAMPLE);
+        let current = state;
+        for (let i = 0; i < 100; i++) {
+            const next = stepGame(current, SAMPLE);
+            if (next.active === null) break;
+            current = next;
+        }
+        // SAMPLE always returns "I": the piece locks at y = ROWS - shapeW.
+        expect(current.active).not.toBeNull();
+        expect(current.lines).toBe(0);
+        expect(current.score).toBe(0);
+        expect(current.active!.type).toBe("I");
+    });
+
+    it("ends the game when a new piece cannot spawn", () => {
+        // Leave only column 3-6 of row 1 filled: an I spawn there collides.
+        const board = createEmptyBoard();
+        for (const col of [3, 4, 5, 6]) board[1][col] = "I";
+        const state: TetrisState = {
+            board,
+            active: null,
+            next: "I",
+            score: 0,
+            lines: 0,
+            level: 1,
+            over: false,
+        };
+        const locked = lockPiece(state, SAMPLE);
+        expect(locked.over).toBe(true);
+    });
+});
+
+describe("hardDrop", () => {
+    it("drops to the bottom, locks, and continues", () => {
+        const state = createInitialState(SAMPLE);
+        const dropped = hardDrop(state, SAMPLE);
+        expect(dropped.over).toBe(false);
+        expect(dropped.active!.type).toBe("I");
+        // An I piece lands on rows 16-19, leaving row 15 empty.
+        const locked = resolveBoard(dropped);
+        expect(locked[15].every((cell) => cell === null)).toBe(true);
+    });
+
+    it("clears a full row dropped into", () => {
+        const state = createInitialState(SAMPLE);
+        // Fill row 19 everywhere except columns 3-6, then drop an I there.
+        for (const col of [0, 1, 2, 7, 8, 9]) {
+            state.board[19][col] = "J";
+        }
+        const dropped = hardDrop(state, SAMPLE);
+        expect(dropped.lines).toBe(1);
+        expect(dropped.score).toBe(100);
+    });
+});
+
+describe("resolveBoard", () => {
+    it("overlays the active piece on the static board", () => {
+        const state = createInitialState(SAMPLE);
+        const board = resolveBoard(state);
+        const cells = state.active!.shape.flatMap((row, r) =>
+            row.map((v, c) => [state.active!.x + c, state.active!.y + r, v]),
+        );
+        for (const [x, y, v] of cells) {
+            if (!v || y < 0 || x < 0 || x >= TETRIS_COLS || y >= TETRIS_ROWS) continue;
+            expect(board[y][x]).toBe("I");
+        }
+    });
+});

--- a/lib/tetris.ts
+++ b/lib/tetris.ts
@@ -1,0 +1,280 @@
+// Pure, framework-free Tetris engine. No React, DOM, or DB access — every
+// function transforms plain values so the logic is unit-testable and the
+// React component just wires it to input and rendering.
+
+export const TETRIS_COLS = 10;
+export const TETRIS_ROWS = 20;
+export const TETRIS_SPAWN_COLS = 3; // matched to every 3-wide piece
+
+export type TetrominoType = "I" | "O" | "T" | "S" | "Z" | "J" | "L";
+
+export type TetrisCell = TetrominoType | null;
+// [row][col]; row 0 is the top of the well.
+export type TetrisBoard = TetrisCell[][];
+
+export interface TetrisPiece {
+  type: TetrominoType;
+  // Binary matrix of the piece's current rotation.
+  shape: number[][];
+  x: number; // column of the shape's left edge
+  y: number; // row of the shape's top edge
+}
+
+export interface TetrisState {
+  board: TetrisBoard;
+  active: TetrisPiece | null;
+  next: TetrominoType | null;
+  score: number;
+  lines: number;
+  level: number;
+  over: boolean;
+}
+
+export const TETROMINO_SHAPES: Record<TetrominoType, number[][]> = {
+  I: [
+    [0, 0, 0, 0],
+    [1, 1, 1, 1],
+    [0, 0, 0, 0],
+    [0, 0, 0, 0],
+  ],
+  O: [
+    [1, 1],
+    [1, 1],
+  ],
+  T: [
+    [0, 1, 0],
+    [1, 1, 1],
+    [0, 0, 0],
+  ],
+  S: [
+    [0, 1, 1],
+    [1, 1, 0],
+    [0, 0, 0],
+  ],
+  Z: [
+    [1, 1, 0],
+    [0, 1, 1],
+    [0, 0, 0],
+  ],
+  J: [
+    [1, 0, 0],
+    [1, 1, 1],
+    [0, 0, 0],
+  ],
+  L: [
+    [0, 0, 1],
+    [1, 1, 1],
+    [0, 0, 0],
+  ],
+};
+
+export const TETROMINO_TYPES: TetrominoType[] = [
+  "I",
+  "O",
+  "T",
+  "S",
+  "Z",
+  "J",
+  "L",
+];
+
+export function createEmptyBoard(): TetrisBoard {
+  return Array.from({ length: TETRIS_ROWS }, () =>
+    Array<TetrisCell>(TETRIS_COLS).fill(null),
+  );
+}
+
+// Rotates a binary shape 90 degrees clockwise.
+export function rotateCW(shape: number[][]): number[][] {
+  const rows = shape.length;
+  const cols = shape[0].length;
+  const rotated = Array.from({ length: cols }, () =>
+    Array<number>(rows).fill(0),
+  );
+  for (let r = 0; r < rows; r++) {
+    for (let c = 0; c < cols; c++) {
+      rotated[c][rows - 1 - r] = shape[r][c];
+    }
+  }
+  return rotated;
+}
+
+export function spawnPiece(type: TetrominoType): TetrisPiece {
+  const shape = TETROMINO_SHAPES[type].map((row) => [...row]);
+  return {
+    type,
+    shape,
+    x: Math.floor((TETRIS_COLS - shape[0].length) / 2),
+    y: 0,
+  };
+}
+
+// Absolute board coordinates of every filled cell in a piece.
+export function pieceCells(
+  piece: TetrisPiece,
+): { x: number; y: number }[] {
+  const cells: { x: number; y: number }[] = [];
+  for (let r = 0; r < piece.shape.length; r++) {
+    for (let c = 0; c < piece.shape[r].length; c++) {
+      if (piece.shape[r][c]) cells.push({ x: piece.x + c, y: piece.y + r });
+    }
+  }
+  return cells;
+}
+
+// True when a shape at (x, y) overlaps a filled cell or leaves the well.
+// Rows above the top of the board are allowed so pieces spawn gradually.
+export function collides(
+  board: TetrisBoard,
+  shape: number[][],
+  x: number,
+  y: number,
+): boolean {
+  for (let r = 0; r < shape.length; r++) {
+    for (let c = 0; c < shape[r].length; c++) {
+      if (!shape[r][c]) continue;
+      const col = x + c;
+      const row = y + r;
+      if (col < 0 || col >= TETRIS_COLS || row >= TETRIS_ROWS) return true;
+      if (row >= 0 && board[row][col]) return true;
+    }
+  }
+  return false;
+}
+
+export function mergePiece(state: TetrisState): TetrisState {
+  const board = state.board.map((row) => [...row]);
+  if (state.active) {
+    for (const { x, y } of pieceCells(state.active)) {
+      if (y >= 0 && y < TETRIS_ROWS && x >= 0 && x < TETRIS_COLS) {
+        board[y][x] = state.active.type;
+      }
+    }
+  }
+  return { ...state, board, active: null };
+}
+
+export function clearFullLines(
+  board: TetrisBoard,
+): { board: TetrisBoard; cleared: number } {
+  const remaining = board.filter((row) => row.some((cell) => cell === null));
+  const cleared = TETRIS_ROWS - remaining.length;
+  const fresh = createEmptyBoard();
+  for (let i = 0; i < remaining.length; i++) {
+    fresh[TETRIS_ROWS - remaining.length + i] = remaining[i];
+  }
+  return { board: fresh, cleared };
+}
+
+// Classic scoring: 100/300/500/800 × current level for 1/2/3/4 lines.
+export function scoreForLines(cleared: number, level: number): number {
+  const base = [0, 100, 300, 500, 800];
+  const idx = Math.min(Math.max(cleared, 0), 4);
+  return base[idx] * Math.max(level, 1);
+}
+
+export function levelForLines(lines: number): number {
+  return Math.floor(Math.max(lines, 0) / 10) + 1;
+}
+
+// Milliseconds between gravity steps for a level. The client calls this.
+export function gravityMs(level: number): number {
+  return Math.max(100, 800 - (level - 1) * 70);
+}
+
+// Locks the active piece, clears full lines, scores them, and spawns the next
+// piece. `sample` draws the piece that follows the current `next`; passing it
+// in keeps the engine deterministic and testable.
+export function lockPiece(
+  state: TetrisState,
+  sample: () => TetrominoType,
+): TetrisState {
+  const merged = mergePiece(state);
+  const { board, cleared } = clearFullLines(merged.board);
+  const lines = merged.lines + cleared;
+  const level = levelForLines(lines);
+  const score = merged.score + scoreForLines(cleared, merged.level);
+
+  const active = spawnPiece(state.next ?? sample());
+  const next = sample();
+  const over = collides(board, active.shape, active.x, active.y);
+
+  return { board, active, next, score, lines, level, over };
+}
+
+export function createInitialState(sample: () => TetrominoType): TetrisState {
+  const board = createEmptyBoard();
+  const active = spawnPiece(sample());
+  const next = sample();
+  const over = collides(board, active.shape, active.x, active.y);
+  return { board, active, next, score: 0, lines: 0, level: 1, over };
+}
+
+export function movePiece(
+  state: TetrisState,
+  dx: number,
+  dy: number,
+): TetrisState {
+  if (!state.active || state.over) return state;
+  const x = state.active.x + dx;
+  const y = state.active.y + dy;
+  if (collides(state.board, state.active.shape, x, y)) return state;
+  return { ...state, active: { ...state.active, x, y } };
+}
+
+// Rotates clockwise with a simple wall kick (try in place, then 1 column left,
+// then 1 column right).
+export function rotatePiece(state: TetrisState): TetrisState {
+  if (!state.active || state.over) return state;
+  const shape = rotateCW(state.active.shape);
+  for (const kick of [0, -1, 1]) {
+    const x = state.active.x + kick;
+    if (!collides(state.board, shape, x, state.active.y)) {
+      return { ...state, active: { ...state.active, shape, x } };
+    }
+  }
+  return state;
+}
+
+export function hardDrop(
+  state: TetrisState,
+  sample: () => TetrominoType,
+): TetrisState {
+  if (!state.active || state.over) return state;
+  let y = state.active.y;
+  while (!collides(state.board, state.active.shape, state.active.x, y + 1)) {
+    y++;
+  }
+  return lockPiece({ ...state, active: { ...state.active, y } }, sample);
+}
+
+// Advances gravity by one row; locks when the piece cannot drop further.
+export function stepGame(
+  state: TetrisState,
+  sample: () => TetrominoType,
+): TetrisState {
+  if (!state.active || state.over) return state;
+  const moved = { ...state, active: { ...state.active, y: state.active.y + 1 } };
+  if (!collides(state.board, moved.active.shape, moved.active.x, moved.active.y)) {
+    return moved;
+  }
+  return lockPiece(state, sample);
+}
+
+export function randomTetrominoType(rand: () => number): TetrominoType {
+  return TETROMINO_TYPES[Math.floor(rand() * TETROMINO_TYPES.length)];
+}
+
+// Board as it should be rendered: static cells plus the falling piece. Strictly
+// pure, so the component can call it during render.
+export function resolveBoard(state: TetrisState): TetrisBoard {
+  const board = state.board.map((row) => [...row]);
+  if (state.active) {
+    for (const { x, y } of pieceCells(state.active)) {
+      if (y >= 0 && y < TETRIS_ROWS && x >= 0 && x < TETRIS_COLS) {
+        board[y][x] = state.active.type;
+      }
+    }
+  }
+  return board;
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -518,4 +518,59 @@ export const VID_REPORT_CATEGORIES = [
   "other",
 ] as const;
 
+// ---------------------------------------------------------------- Games
+
+export const GAME_IDS = ["tetris"] as const;
+export type GameId = (typeof GAME_IDS)[number];
+
+// One document per (gameId, userId); bestScore is the user's all-time best for
+// that game, updated only when a new record is set.
+export interface GameScore {
+  _id: ObjectId;
+  gameId: GameId;
+  userId: ObjectId;
+  bestScore: number;
+  gamesPlayed: number;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface GameScoreAuthorCard {
+  _id: string;
+  username: string;
+  displayName: string;
+  photo: string | null;
+}
+
+export interface SerializedGameScore {
+  _id: string;
+  gameId: GameId;
+  userId: string;
+  bestScore: number;
+  gamesPlayed: number;
+  createdAt: string;
+  updatedAt: string;
+  author: GameScoreAuthorCard;
+}
+
+// Cursor for paginating the leaderboard. Rows sort by bestScore desc, then
+// updatedAt asc (first player to reach a score places higher on ties), then
+// _id asc, mirroring the backing composite index.
+export interface GameScoreCursor {
+  bestScore: number;
+  updatedAt: string;
+  _id: string;
+}
+
+export interface GameLeaderboard {
+  gameId: GameId;
+  scores: SerializedGameScore[];
+  nextCursor: GameScoreCursor | null;
+  // Viewer statistics (null when no one is logged in). myRank is 1-based and
+  // counts every player whose best score ranks above the viewer's.
+  myRank: number | null;
+  myBest: number | null;
+  myGamesPlayed: number | null;
+}
+
 export type VidReportCategory = (typeof VID_REPORT_CATEGORIES)[number];

--- a/lib/usernames.ts
+++ b/lib/usernames.ts
@@ -8,6 +8,7 @@ export const RESERVED_USERNAMES = [
     "edit",
     "forgot-password",
     "friends",
+    "games",
     "groups",
     "layouts",
     "login",

--- a/scripts/seed-dev.mjs
+++ b/scripts/seed-dev.mjs
@@ -1,0 +1,193 @@
+// Dev-only seeder: creates a single demo login and a handful of Tetris
+// leaderboard entries so the app is usable without MongoDB setup, Firebase,
+// R2, or Resend. Never run against a production database.
+//
+// Usage:
+//   node scripts/seed-dev.mjs                 # upsert everything (idempotent)
+//   node scripts/seed-dev.mjs --fresh         # wipe users/sessions/gameScores first
+//   node scripts/seed-dev.mjs --uri=mongodb://localhost:27017/genggeng
+//
+// Demo login after seeding: demo / demo1234
+
+import { MongoClient, ObjectId } from "mongodb";
+import { scryptSync, randomBytes } from "node:crypto";
+import { readFileSync, existsSync } from "node:fs";
+
+// Matches lib/auth.ts (salt:scrypt(password, salt, 64) hex).
+function hashPassword(password) {
+  const salt = randomBytes(16).toString("hex");
+  const hash = scryptSync(password, salt, 64).toString("hex");
+  return `${salt}:${hash}`;
+}
+
+const DEMO = {
+  username: "demo",
+  email: "demo@genggi.local",
+  password: "demo1234",
+  displayName: "Demo",
+  bestScore: 5300,
+};
+
+// Leaderboard flavor: synthetic players that back the gameScores rows. None of
+// these can log in (no password hash), they just make /games look alive.
+const BOTS = [
+  ["blockbuster88", "Blockbuster", 9120, 41],
+  ["tetrisqueen", "Tetris Queen", 8700, 33],
+  ["retrobyte", "Retrobyte", 7950, 26],
+  ["matrixfall", "MatrixFall", 7410, 19],
+  ["dropzone", "DropZoner", 6680, 24],
+  ["pedrothestacker", "Pedro", 6040, 15],
+  ["lineclearz", "LineClearZ", 5770, 12],
+  ["pixelmason", "Pixel Mason", 4490, 9],
+  ["sevenbag", "SevenBag", 3880, 7],
+  ["rookielog", "Rookie", 2150, 4],
+];
+
+function resolveUri(cliUri) {
+  if (cliUri) return cliUri;
+  if (process.env.MONGODB_URI) return process.env.MONGODB_URI;
+  const envFile = new URL("../.env.local", import.meta.url);
+  if (existsSync(envFile)) {
+    for (const line of readFileSync(envFile, "utf8").split("\n")) {
+      const match = line.match(/^\s*MONGODB_URI\s*=\s*"?([^"#]+)"?\s*$/);
+      if (match) return match[1].trim();
+    }
+  }
+  return "mongodb://localhost:27017/genggeng";
+}
+
+function profileFields() {
+  return {
+    firstName: "",
+    lastName: "",
+    gender: "",
+    location: "",
+    interests: [],
+    relationshipStatus: "Single",
+    orientation: "",
+    zodiac: "",
+    bodyType: "",
+    occupation: "",
+    aboutMe: "",
+    hereFor: "",
+    whoIdLikeToMeet: "",
+    favoriteSong: "",
+    mood: "",
+    awayMessage: "",
+    photo: null,
+    theme: { border: "#6699cc", customCss: "" },
+    profileViews: 0,
+    lastActive: new Date(),
+    isPrivate: false,
+    hideFromSearch: false,
+    whoCanMessage: "everyone",
+    whoCanFriendRequest: "everyone",
+  };
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const fresh = args.includes("--fresh");
+  const uriArg = args.find((a) => a.startsWith("--uri="));
+  const uri = resolveUri(uriArg ? uriArg.slice("--uri=".length) : null);
+
+  const client = new MongoClient(uri, { serverSelectionTimeoutMS: 5000 });
+  await client.connect();
+  const db = client.db();
+  const users = db.collection("users");
+  const scores = db.collection("gameScores");
+
+  console.log(`Connected to ${uri}`);
+
+  if (fresh) {
+    await Promise.all([
+      db.dropCollection("sessions").catch(() => {}),
+      db.dropCollection("gameScores").catch(() => {}),
+      db.dropCollection("gameScoreSubmissions").catch(() => {}),
+      db.dropCollection("users").catch(() => {}),
+    ]);
+    console.log("Dropped users, sessions, gameScores (--fresh)");
+  }
+
+  // --- Demo login user ----------------------------------------------------
+  const demo = {
+    _id: new ObjectId(),
+    username: DEMO.username,
+    email: DEMO.email,
+    passwordHash: hashPassword(DEMO.password),
+    role: "user",
+    banned: false,
+    emailVerified: true,
+    authProvider: "local",
+    onboardingCompleted: true,
+    createdAt: new Date(),
+    displayName: DEMO.displayName,
+    ...profileFields(),
+  };
+
+  const demoUser = await users.findOne({ username: DEMO.username });
+  if (demoUser) {
+    await users.updateOne({ _id: demoUser._id }, { $set: { ...demo, _id: demoUser._id } });
+  } else {
+    await users.insertOne(demo);
+  }
+  const demoId = (await users.findOne({ username: DEMO.username }))._id;
+
+  // --- Leaderboard players ------------------------------------------------
+  const seeded = [];
+  for (const [username, displayName, bestScore, gamesPlayed] of BOTS) {
+    const bot = {
+      _id: new ObjectId(),
+      username,
+      email: `${username}@genggi.local`,
+      passwordHash: "",
+      role: "user",
+      banned: false,
+      emailVerified: true,
+      authProvider: "local",
+      onboardingCompleted: true,
+      createdAt: new Date(Date.now() - Math.floor(Math.random() * 180) * 86400000),
+      displayName,
+      ...profileFields(),
+    };
+    await users.replaceOne({ username }, bot, { upsert: true });
+    seeded.push([(await users.findOne({ username }))._id, bestScore, gamesPlayed]);
+  }
+  seeded.push([demoId, DEMO.bestScore, 3]);
+
+  // --- gameScores (one doc per (gameId, userId) = best score) -------------
+  for (const [userId, bestScore, gamesPlayed] of seeded) {
+    const achievedAt = new Date(
+      Date.now() - Math.floor(Math.random() * 60) * 86400000,
+    );
+    const doc = {
+      gameId: "tetris",
+      userId,
+      bestScore,
+      gamesPlayed,
+      createdAt: achievedAt,
+      updatedAt: achievedAt,
+    };
+    await scores.replaceOne(
+      { gameId: "tetris", userId },
+      doc,
+      { upsert: true },
+    );
+  }
+
+  // --- Guarantee the leaderboard indexes exist -----------------------------
+  await Promise.all([
+    scores.createIndex({ gameId: 1, userId: 1 }, { unique: true }),
+    scores.createIndex({ gameId: 1, bestScore: -1, updatedAt: 1, _id: 1 }),
+  ]);
+
+  await client.close();
+
+  console.log(`Seeded 1 login user + ${seeded.length} leaderboard entries.`);
+  console.log("Login: demo / demo1234 → http://localhost:3000/games");
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exit(1);
+});


### PR DESCRIPTION
Add a casual Tetris game at /games with a pure, unit-tested engine and a global leaderboard system designed for easy expansion to future games.

Game engine (lib/tetris.ts):
- Framework-free Tetris engine with wall kicks, 7-bag randomizer, gravity, hard/soft drop, and classic scoring (100/300/500/800 × level)
- All state is serializable plain objects; RNG is injected as a callback for deterministic testing

Leaderboard system (lib/games.ts):
- Generic gameId-based design (currently tetris)
- One document per (gameId, userId) tracking bestScore and gamesPlayed
- Cursor-based pagination, ties broken by earliest-to-reach
- Submission cooldown (3s) for casual anti-abuse
- Server re-validates scores; play time minimum enforced (5s)

UI (app/components/TetrisGame.tsx):
- Keyboard + touch controls (arrow keys, WASD-adjacent)
- Pause, level progression, next-piece preview
- Auto-submits score when logged in; login prompt when not

Infrastructure:
- NavBar link to /games
- Dev seeder (scripts/seed-dev.mjs) creates demo login (demo/demo1234) with leaderboard entries
- Unit tests for engine and validation helpers
- README updated with Games section and local quickstart guide

Adding future games requires only a new engine + component + page; the leaderboard, score submission, and anti-abuse systems work automatically.